### PR TITLE
+Compatibilidade com outros sistemas

### DIFF
--- a/bootzinho.sh
+++ b/bootzinho.sh
@@ -11,33 +11,33 @@ fi
 #Função de verificar dependência - Usada para verificar se o pacote pv encontra-se instalado no sistema.
 verificarDependencia(){
     if [ -n "$dependencias" ]; then
-      $info --text="Voce ja possui todas as dependencias para o Bootizinho"
+      $info --text="Voce ja possui todas as dependencias para o Bootizinho" 2> /dev/null
     else
-      $info --text="Voce precisa instalar o pacote PV para funcionamento correto do Bootizinho.\nDigite 'sudo apt-get install pv' em seu terminal\nDepois volte a executar o Bootizinho."
+      $info --text="Voce precisa instalar o pacote PV para funcionamento correto do Bootizinho.\nDigite 'sudo apt-get install pv' em seu terminal\nDepois volte a executar o Bootizinho." 2> /dev/null
     fi
 }
 
 #Verificando a dependência
 dependencias=$(whereis pv | grep "pv" | cut -d':' -f1);
 verificarDependencia
-$info --text="Bootizinho, facil e gratuito"
+$info --text="Bootizinho, facil e gratuito" 2> /dev/null
 sair
-$info --text="Primeiro escolha o pendrive!. Procure no terminal e siga o exemplo."
+$info --text="Primeiro escolha o pendrive!. Procure no terminal e siga o exemplo." 2> /dev/null
 sair
 clear
 sudo fdisk -l
 echo -e " \033[1;37mLOCALIZE O SEU PENDRIVE ACIMA\033[1;37m!"
-pendrive=$(zenity --entry --title="$titulo" --text="Digite o caminho do seu pendrive" --entry-text="Ex: /dev/sdb1");
+pendrive=$(zenity --entry --title="$titulo" --text="Digite o caminho do seu pendrive" --entry-text="Ex: /dev/sdb1" 2> /dev/null);
 sair
 clear
-$info --text="Escolha a imagem ISO que deseja utilizar!"
+$info --text="Escolha a imagem ISO que deseja utilizar!" 2> /dev/null
 sair
 clear
-imagemISO=$(zenity --title="$titulo" --file-selection);
+imagemISO=$(zenity --title="$titulo" --file-selection 2> /dev/null);
 sair
 clear
-zenity --warning --title="$titulo - Confirmando informacoes" --text="Confira suas informacoes:\nImagem ISO: $imagemISO\nPendrive: $pendrive." --ellipsize
-zenity --question --title="$titulo" --text="As informacoes estao corretas e deseja continuar?"
+zenity --warning --title="$titulo - Confirmando informacoes" --text="Confira suas informacoes:\nImagem ISO: $imagemISO\nPendrive: $pendrive." --ellipsize 2> /dev/null
+zenity --question --title="$titulo" --text="As informacoes estao corretas e deseja continuar?" 2> /dev/null
 sair
 
 case  $? in
@@ -48,7 +48,7 @@ case  $? in
 }
 
 Voltar(){
-	zenity --question --text="Deseja encerrar o programa?"
+	zenity --question --text="Deseja encerrar o programa?" 2> /dev/null
 	if [ "$?" -eq "0" ]; then
 	  exit
   elif [ "$?" -q "1" ]; then
@@ -58,11 +58,11 @@ Voltar(){
 }
 
 Continuar(){
-	zenity --question --text="Deseja formatar o pendrive no formato fat 32?"
+	zenity --question --text="Deseja formatar o pendrive no formato fat 32?" 2> /dev/null
 	if [ "$?" -eq 0 ]; then
 		echo "formatando.. $pendrive"
 		sudo umount $pendrive
-		sudo mkfs.vfat -I $pendrive | zenity --progress --title='Progresso' --text="Formatando..." --percentage=0 --pulsate
+		sudo mkfs.vfat -I $pendrive | zenity --progress --title='Progresso' --text="Formatando..." --percentage=0 --pulsate 2> /dev/null
 		Gravar
 	else
 		Gravar
@@ -72,12 +72,12 @@ Main
 }
 
 Gravar(){
-	zenity --question --text="Deseja iniciar a gravacao da imagem ISO no pendrive: $pendrive ?"
+	zenity --question --text="Deseja iniciar a gravacao da imagem ISO no pendrive: $pendrive ?" 2> /dev/null
 	if [ "$?" -eq 0 ]; then
 		sudo umount $pendrive
     clear
-    zenity --info --title="$titulo" --text="Nao feche o seu terminal! O processo pode ser demorado, o Bootzinho ira avisa-lo assim que terminar!"
-		pv $imagemISO | sudo dd of=$pendrive && sync | zenity --progress --title="Progresso" --text="Concluido" --percentage=0 --pulsate
+    zenity --info --title="$titulo" --text="Nao feche o seu terminal! O processo pode ser demorado, o Bootzinho ira avisa-lo assim que terminar!" 2> /dev/null
+		pv $imagemISO | sudo dd of=$pendrive && sync | zenity --progress --title="Progresso" --text="Concluido" --percentage=0 --pulsate 2> /dev/null
     Voltar
   else
 		Voltar

--- a/bootzinho.sh
+++ b/bootzinho.sh
@@ -11,16 +11,16 @@ fi
 #Função de verificar dependência - Usada para verificar se o pacote pv encontra-se instalado no sistema.
 verificarDependencia(){
     if [ -n "$dependencias" ]; then
-      $info --text="Você já possui todas as dependencias para o Bootizinho"
+      $info --text="Voce ja possui todas as dependencias para o Bootizinho"
     else
-      $info --text="Você precisa instalar o pacote PV para funcionamento correto do Bootizinho.\nDigite 'sudo apt-get install pv' em seu terminal\nDepois volte a executar o Bootizinho."
+      $info --text="Voce precisa instalar o pacote PV para funcionamento correto do Bootizinho.\nDigite 'sudo apt-get install pv' em seu terminal\nDepois volte a executar o Bootizinho."
     fi
 }
 
 #Verificando a dependência
 dependencias=$(dpkg -l | grep "pv");
 verificarDependencia
-$info --text="Bootizinho, fácil e gratuito"
+$info --text="Bootizinho, facil e gratuito"
 sair
 $info --text="Primeiro escolha o pendrive!. Procure no terminal e siga o exemplo."
 sair
@@ -36,8 +36,8 @@ clear
 imagemISO=$(zenity --title="$titulo" --file-selection);
 sair
 clear
-zenity --warning --title="$titulo - Confirmando informações" --text="Confira suas informações:\nImagem ISO: $imagemISO\nPendrive: $pendrive." --ellipsize
-zenity --question --title="$titulo" --text="As informações estão corretas e deseja continuar?"
+zenity --warning --title="$titulo - Confirmando informacoes" --text="Confira suas informacoes:\nImagem ISO: $imagemISO\nPendrive: $pendrive." --ellipsize
+zenity --question --title="$titulo" --text="As informacoes estao corretas e deseja continuar?"
 sair
 
 case  $? in
@@ -72,12 +72,12 @@ Main
 }
 
 Gravar(){
-	zenity --question --text="Deseja iniciar a gravação da imagem ISO no pendrive: $pendrive ?"
+	zenity --question --text="Deseja iniciar a gravacao da imagem ISO no pendrive: $pendrive ?"
 	if [ "$?" -eq 0 ]; then
 		sudo umount $pendrive
     clear
-    zenity --info --title="$titulo" --text="Não feche o seu terminal! O processo pode ser demorado, o Bootzinho irá avisa-lo assim que terminar!"
-		pv $imagemISO | sudo dd of=$pendrive && sync | zenity --progress --title="Progresso" --text="Concluído" --percentage=0 --pulsate
+    zenity --info --title="$titulo" --text="Nao feche o seu terminal! O processo pode ser demorado, o Bootzinho ira avisa-lo assim que terminar!"
+		pv $imagemISO | sudo dd of=$pendrive && sync | zenity --progress --title="Progresso" --text="Concluido" --percentage=0 --pulsate
     Voltar
   else
 		Voltar

--- a/bootzinho.sh
+++ b/bootzinho.sh
@@ -18,7 +18,7 @@ verificarDependencia(){
 }
 
 #Verificando a dependência
-dependencias=$(dpkg -l | grep "pv");
+dependencias=$(whereis pv | grep "pv" | cut -d':' -f1);
 verificarDependencia
 $info --text="Bootizinho, facil e gratuito"
 sair


### PR DESCRIPTION
- Removi as acentuações das mensagens do zenity pois estavam gerando erros de sintaxe;
- Alterei a forma de pesquisar se existe o pacote "pv" instalado no sistema, assim fica mais eficiente e compatível com outros sistemas operacionais (distribuições);
- Redirecionei as saídas do zenity para /dev/null, evitando que apareça a mensagem "Gtk-Message: GtkDialog mapped without a transient parent. This is discouraged." no terminal a cada confirmação.